### PR TITLE
Fixed NPE on folders & bumped to IDEA 2023.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,28 +1,29 @@
 plugins {
-    id 'java'
-    id 'org.jetbrains.intellij' version '0.4.16'
+    id("idea")
+    id("org.jetbrains.intellij") version "1.15.0"
 }
 
-group 'com.github.setial'
-version '4.0.2'
+group "com.github.setial"
+version "4.1.0"
 
-sourceCompatibility = 1.8
+sourceCompatibility = 17
 
 repositories {
     mavenCentral()
 }
 
 dependencies {
-    compile 'commons-beanutils:commons-beanutils:1.9.4'
-    compile 'commons-collections:commons-collections:3.2.2'
-    compile 'org.apache.commons:commons-lang3:3.9'
-    compile 'commons-logging:commons-logging:1.2'
-    compile 'org.freemarker:freemarker:2.3.29'
-    testCompile group: 'junit', name: 'junit', version: '4.12'
+    implementation 'commons-beanutils:commons-beanutils:1.9.4'
+    implementation 'commons-collections:commons-collections:3.2.2'
+    implementation 'org.apache.commons:commons-lang3:3.9'
+    implementation 'commons-logging:commons-logging:1.2'
+    implementation 'org.freemarker:freemarker:2.3.32'
+    testImplementation group: 'junit', name: 'junit', version: '4.9'
 }
 
 // See https://github.com/JetBrains/gradle-intellij-plugin/
 intellij {
-    version '2020.1'
+    version.set("2023.2")
+    type.set("IC")
     plugins = ['java']
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 #Fri Jan 31 16:29:09 EET 2020
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.2.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.1-all.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin>
     <id>com.github.setial</id>
     <name>JavaDoc</name>
-    <version>4.0.2</version>
+    <version>4.1.0</version>
     <vendor email="s.timofiychuk@gmail.com" url="http://setial.github.com/intellij-javadocs/">
         Sergey Timofiychuk
     </vendor>
@@ -106,7 +106,7 @@
 
     <!-- please see http://confluence.jetbrains.net/display/IDEADEV/Build+Number+Ranges for description -->
     <!-- supports only intellij idea 15 -->
-    <idea-version since-build="201.6668"/>
+    <idea-version since-build="232.8660"/>
 
     <!-- please see http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/plugin_compatibility.html
          on how to target different products -->
@@ -170,7 +170,7 @@
         <applicationService serviceInterface="com.github.setial.intellijjavadocs.operation.JavaDocWriter"
                             serviceImplementation="com.github.setial.intellijjavadocs.operation.impl.JavaDocWriterImpl"/>
 
-        <projectConfigurable groupId="tools" id="JavaDoc"
+        <projectConfigurable groupId="tools" id="JavaDoc" displayName="JavaDoc"
                              instance="com.github.setial.intellijjavadocs.ui.settings.ConfigPanel"/>
     </extensions>
 </idea-plugin>


### PR DESCRIPTION
Hi,

This PR fixes the exception thrown when generating JavaDoc on folders. So it fixes issue #107.

It also makes the plugin compatible with the latest IDEA API available today (i.e. 2023.2). So it may fix issue #108 as well.

I bumped the plugin version from 4.0.2 to 4.1.0. Is that ok?